### PR TITLE
implement benchmark to measure time without io.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,13 @@
 all: build run
 
 build:
-	cargo build
+	cargo rustc -- -O -g
+
+release:
+	cargo rustc --release -- -g
 
 bench:
+	$(shell ./setup.sh)
 	cargo bench
 
 run:

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+[ ! -f /tmp/test.data ] && dd if=/dev/urandom of=/tmp/test.data  count=50 bs=1M

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,0 +1,6 @@
+dflt:
+	make -C ../ build
+	make -C ../ release
+
+bench:
+	make -C ../ bench


### PR DESCRIPTION
table setup is the culprit:
  test test::bench_refimpl_a    ... bench: 187,992,413 ns/iter (+/- 8,577,192)
  test test::bench_refimpl_b    ... bench:  39,025,651 ns/iter (+/- 2,736,787)
